### PR TITLE
ubx: add function for disabling mb rover operation

### DIFF
--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -220,6 +220,8 @@ public:
 	 */
 	virtual int reset(GPSRestartType restart_type)	{ (void)restart_type; return -1; }
 
+	virtual bool disableUbxMBRover() { return false; }
+
 	float getPositionUpdateRate() { return _rate_lat_lon; }
 	float getVelocityUpdateRate() { return _rate_vel; }
 	void resetUpdateRates();

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2400,3 +2400,42 @@ GPSDriverUBX::reset(GPSRestartType restart_type)
 
 	return -2;
 }
+
+bool GPSDriverUBX::disableUbxMBRover() {
+	if (_mode == UBXMode::RoverWithMovingBase) {
+		UBX_DEBUG("Disabling RoverWithMovingBase, switching to normal operation");
+		int cfg_valset_msg_size = initCfgValset();
+
+		// Disable RTCM input from moving base (UART2)
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0, cfg_valset_msg_size);
+		// Stop sending RELPOSNED
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_I2C, 0, cfg_valset_msg_size);
+		// Enable RTCM input from flight controller (UART1), so corrections from static base can be used
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1, cfg_valset_msg_size);
+
+		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+			UBX_WARN("Error: disableUbxMBRover() failed to send UBX_MSG_CFG_VALSET (%d)", errno);
+			return false;
+		}
+
+		// Perform a position reset, this causes receiver to exit rover mode
+		memset(&_buf.payload_tx_cfg_rst, 0, sizeof(_buf.payload_tx_cfg_rst));
+		_buf.payload_tx_cfg_rst.resetMode = 0x02; // GPS-only software reset
+		_buf.payload_tx_cfg_rst.navBbrMask = 0b10000; // Only reset position
+
+		if (!sendMessage(UBX_MSG_CFG_RST, (uint8_t *)&_buf, sizeof(_buf.payload_tx_cfg_rst))) {
+			UBX_WARN("Error: disableUbxMBRover() failed to send UBX_MSG_CFG_RST (%d)", errno);
+			return false;
+		}
+
+		_disabled_rover_mode = true;
+		return true;
+
+	} else if (_mode == UBXMode::RoverWithMovingBaseUART1){
+		UBX_WARN("Error: disableUbxMBRover() not implemented for RoverWithMovingBaseUART1");
+		return false;
+	} else {
+		UBX_WARN("Error: Attempted to call disableUbxMBRover() when not in rover mode");
+		return false;
+	}
+}

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -927,8 +927,9 @@ public:
 	int configure(unsigned &baudrate, const GPSConfig &config) override;
 	int receive(unsigned timeout) override;
 	int reset(GPSRestartType restart_type) override;
+	bool disableUbxMBRover() override;
 
-	bool shouldInjectRTCM() override { return _mode != UBXMode::RoverWithMovingBase; }
+	bool shouldInjectRTCM() override { return _mode != UBXMode::RoverWithMovingBase || _disabled_rover_mode; }
 
 	enum class Board : uint8_t {
 		unknown = 0,
@@ -1107,6 +1108,7 @@ private:
 
 	const UBXMode _mode;
 	const float _heading_offset;
+	bool _disabled_rover_mode{false};
 };
 
 


### PR DESCRIPTION
A receiver in moving base rover mode will output data with delay up to 1 second if it cannot compute a relative solution. This can for example happen if the moving base experiences degrated signal or power loss.

In such a scenario, the rover might be the only receiver left, and for redundancy it`s important to bring it back into a normal state without delay in order to avoid toilet bowl/position loss.

Testing with an F9P receiver, the quickest way I found to achieve this is to send a soft position reset.