### PR TITLE
ubx: function for re-enabling MB rover

### DIFF
--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -221,6 +221,7 @@ public:
 	virtual int reset(GPSRestartType restart_type)	{ (void)restart_type; return -1; }
 
 	virtual bool disableUbxMBRover() { return false; }
+	virtual bool enableUbxMBRover() { return false; }
 
 	float getPositionUpdateRate() { return _rate_lat_lon; }
 	float getVelocityUpdateRate() { return _rate_vel; }

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2410,7 +2410,7 @@ bool GPSDriverUBX::disableUbxMBRover()
 		// Disable RTCM input from moving base (UART2)
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0, cfg_valset_msg_size);
 		// Stop sending RELPOSNED
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_I2C, 0, cfg_valset_msg_size);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART1, 0, cfg_valset_msg_size);
 		// Enable RTCM input from flight controller (UART1), so corrections from static base can be used
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1, cfg_valset_msg_size);
 

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2401,43 +2401,65 @@ GPSDriverUBX::reset(GPSRestartType restart_type)
 	return -2;
 }
 
+bool GPSDriverUBX::softResetPosition()
+{
+	memset(&_buf.payload_tx_cfg_rst, 0, sizeof(_buf.payload_tx_cfg_rst));
+	_buf.payload_tx_cfg_rst.resetMode = 0x02; // GPS-only software reset
+	_buf.payload_tx_cfg_rst.navBbrMask = 0b10000; // Only reset position
+
+	return sendMessage(UBX_MSG_CFG_RST, (uint8_t *)&_buf, sizeof(_buf.payload_tx_cfg_rst));
+}
+
 bool GPSDriverUBX::disableUbxMBRover()
 {
-	if (_mode == UBXMode::RoverWithMovingBase) {
-		UBX_DEBUG("Disabling RoverWithMovingBase, switching to normal operation");
-		int cfg_valset_msg_size = initCfgValset();
+	UBX_DEBUG("Disabling RoverWithMovingBase");
+	int cfg_valset_msg_size = initCfgValset();
 
-		// Disable RTCM input from moving base (UART2)
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0, cfg_valset_msg_size);
-		// Stop sending RELPOSNED
+	// Disable RTCM input from moving base (UART2)
+	cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0, cfg_valset_msg_size);
+	// Stop sending RELPOSNED
 	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART1, 0, cfg_valset_msg_size);
-		// Enable RTCM input from flight controller (UART1), so corrections from static base can be used
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1, cfg_valset_msg_size);
+	// Enable RTCM input from flight controller (UART1), so corrections from static base can be used
+	cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1, cfg_valset_msg_size);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-			UBX_WARN("Error: disableUbxMBRover() failed to send UBX_MSG_CFG_VALSET (%d)", errno);
-			return false;
-		}
-
-		// Perform a position reset, this causes receiver to exit rover mode
-		memset(&_buf.payload_tx_cfg_rst, 0, sizeof(_buf.payload_tx_cfg_rst));
-		_buf.payload_tx_cfg_rst.resetMode = 0x02; // GPS-only software reset
-		_buf.payload_tx_cfg_rst.navBbrMask = 0b10000; // Only reset position
-
-		if (!sendMessage(UBX_MSG_CFG_RST, (uint8_t *)&_buf, sizeof(_buf.payload_tx_cfg_rst))) {
-			UBX_WARN("Error: disableUbxMBRover() failed to send UBX_MSG_CFG_RST (%d)", errno);
-			return false;
-		}
-
-		_disabled_rover_mode = true;
-		return true;
-
-	} else if (_mode == UBXMode::RoverWithMovingBaseUART1) {
-		UBX_WARN("Error: disableUbxMBRover() not implemented for RoverWithMovingBaseUART1");
-		return false;
-
-	} else {
-		UBX_WARN("Error: Attempted to call disableUbxMBRover() when not in rover mode");
+	if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		UBX_WARN("Error: disableUbxMBRover() failed to send UBX_MSG_CFG_VALSET (%d)", errno);
 		return false;
 	}
+
+	if (!softResetPosition()) {
+		UBX_WARN("Error: disableUbxMBRover() failed to reset receiver (%d)", errno);
+		return false;
+	}
+
+
+
+	_disabled_rover_mode = true;
+	return true;
+}
+
+bool GPSDriverUBX::enableUbxMBRover()
+{
+	UBX_DEBUG("Enabling RoverWithMovingBase");
+	int cfg_valset_msg_size = initCfgValset();
+
+	// Enable RTCM input from moving base (UART2)
+	cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1, cfg_valset_msg_size);
+	// Start sending RELPOSNED
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART1, 1, cfg_valset_msg_size);
+	// Disable RTCM input from flight controller (UART1)
+	cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 0, cfg_valset_msg_size);
+
+	if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		UBX_WARN("Error: enableUbxMBRover() failed to send UBX_MSG_CFG_VALSET (%d)", errno);
+		return false;
+	}
+
+	if (!softResetPosition()) {
+		UBX_WARN("Error: enableUbxMBRover() failed to reset receiver (%d)", errno);
+		return false;
+	}
+
+	_disabled_rover_mode = false;
+	return true;
 }

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -699,6 +699,9 @@ int GPSDriverUBX::configureDevice(const GNSSSystemsMask &gnssSystems)
 			return -1;
 		}
 
+		// In case the receiver was in disabled rover mode before a flight controller reboot.
+		softResetPosition();
+
 	} else if (_mode == UBXMode::MovingBase) {
 		UBX_DEBUG("Configuring UART2 for moving base");
 		// enable RTCM output on uart2 + set baudrate

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1074,6 +1074,16 @@ private:
 
 	/**
 	 * Perform a soft position reset
+	 * A u-blox F9P enters "rover mode" when it gets RTCM 4072.1 messages from a moving base.
+	 * The quickest way I've found to exit "rover mode" is to send a soft position reset.
+	 *
+	 * A reset is also required when switching from "normal operation" with a static base to
+	 * rover mode. If not, it won't get RTK fix with the data from the moving base.
+	 * I'm not totally sure of the mechanism here.
+	 *
+	 * When performing a soft position reset, the receiver drops to no fix (0) temporarily.
+	 * In all out testing so far, it recovers within one second.
+	 *
 	 * @return true on success, false on write error (errno set)
 	 */
 	bool softResetPosition();

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -928,6 +928,7 @@ public:
 	int receive(unsigned timeout) override;
 	int reset(GPSRestartType restart_type) override;
 	bool disableUbxMBRover() override;
+	bool enableUbxMBRover() override;
 
 	bool shouldInjectRTCM() override { return _configured && (_mode != UBXMode::RoverWithMovingBase || _disabled_rover_mode); }
 
@@ -1070,6 +1071,12 @@ private:
 	 * Wait for message acknowledge
 	 */
 	int waitForAck(const uint16_t msg, const unsigned timeout, const bool report);
+
+	/**
+	 * Perform a soft position reset
+	 * @return true on success, false on write error (errno set)
+	 */
+	bool softResetPosition();
 
 	const Interface _interface{};
 


### PR DESCRIPTION
Additions to https://github.com/aviant-tech/PX4-GPSDrivers/pull/1

This allows to put the rover back into rover mode again after a fallback.

Some refactoring to avoid three-fold repetition of GPS reset code.
Also removed some unnecessary checks to make the code less defensive.