### PR TITLE
Port changes from our 1.13 branch

### DIFF
--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -231,6 +231,9 @@ public:
 	 */
 	virtual int reset(GPSRestartType restart_type)	{ (void)restart_type; return -1; }
 
+	virtual bool disableUbxMBRover() { return false; }
+	virtual bool enableUbxMBRover() { return false; }
+
 	float getPositionUpdateRate() { return _rate_lat_lon; }
 	float getVelocityUpdateRate() { return _rate_vel; }
 	void resetUpdateRates();

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -993,7 +993,7 @@ public:
 	int receive(unsigned timeout) override;
 	int reset(GPSRestartType restart_type) override;
 
-	bool shouldInjectRTCM() override { return _mode != UBXMode::RoverWithMovingBase; }
+	bool shouldInjectRTCM() override { return _configured && _mode != UBXMode::RoverWithMovingBase; }
 
 	enum class Board : uint8_t {
 		unknown = 0,


### PR DESCRIPTION
Added our changes on top of the submodule pointer for `v1.15.4` in the main repo. Essentially a squash of our commits to https://github.com/aviant-tech/PX4-GPSDrivers/commits/aviant/1.13-dev/

Switched two statements to use `cfgValsetPort` instead of `cfgValset` since `UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART1` has been removed from the header. 

(Verified with `make format` this time)