### PR TITLE
ubx: fix overflow (#176)

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1460,7 +1460,7 @@ GPSDriverUBX::payloadRxInit()
 		break;
 
 	case UBX_MSG_RXM_RTCM:
-		if (_rx_payload_length < sizeof(ubx_payload_rx_rxm_rtcm_t)) {
+		if (_rx_payload_length != sizeof(ubx_payload_rx_rxm_rtcm_t)) {
 			_rx_state = UBX_RXMSG_ERROR_LENGTH;
 
 		} else if (!_configured) {

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -711,6 +711,7 @@ typedef struct {
 	uint8_t  flags;
 	uint16_t subType;
 	uint16_t refStationID;
+	uint16_t msgType;
 } ubx_payload_rx_rxm_rtcm_t;
 
 /* Rx ACK-ACK */


### PR DESCRIPTION
Problem: UART errors could cause malformed RXM-RTCM messages that corrupted the heap.

Reproduction: Flash https://github.com/aviant-tech/PX4-GPSDrivers/pull/7 and wait 30 seconds, it will self-inject a bad message and hardfault.

Development document: https://aviant.atlassian.net/wiki/spaces/TECHNICAL/pages/2085257220/

Verification: 10x crashes before fix, no crashes after fix: https://aviant.atlassian.net/wiki/spaces/TECHNICAL/pages/2085257220/2026-02-10+1.15+crash+dumps#Verifying-fix%3A